### PR TITLE
Remove stray DummyWind connection from power_balance scenario

### DIFF
--- a/tutorials/power_balance/data/Tutorial_Power_Balance_a.yaml
+++ b/tutorials/power_balance/data/Tutorial_Power_Balance_a.yaml
@@ -129,10 +129,6 @@ connections:
 - from: Load1.load_dem
   to: Controller1.load_dem
 
-  #use a random parameter to give an input for the 'u'
-- from: CSV_pv.Ta
-  to: DummyWind.u
-
 monitor:
   file: './out_Tutorial_Power_Balance_a.csv'
   items:


### PR DESCRIPTION
Tutorial_Power_Balance_a.yaml contained a leftover debug connection 'CSV_pv.Ta -> DummyWind.u' that referenced a non-existent model. The engine raises a ValueError on it, but the notebook cell that runs the scenario uses %%capture, which swallowed the error. As a result the output CSV was never regenerated and the test compared a stale committed file, failing on Controller1.res_load / PV1.pv_gen.

Removing the bogus connection lets the scenario run again and the power_balance test pass (full tutorial suite green locally).

Introduced in 0683b4f.